### PR TITLE
Add (optional) collection identifier to records going into the store.

### DIFF
--- a/ft-coroutines-kafka-retry/src/main/kotlin/tech/figure/kafka/coroutines/retry/store/InMemoryConsumerRecordStore.kt
+++ b/ft-coroutines-kafka-retry/src/main/kotlin/tech/figure/kafka/coroutines/retry/store/InMemoryConsumerRecordStore.kt
@@ -38,6 +38,9 @@ fun <K, V> inMemoryConsumerRecordStore(
         // Find and update the record in the data set.
         data[data.indexOf(record)].also {
             it.data = item
+            it.attempt++
+            it.lastAttempted = OffsetDateTime.now()
+            it.lastException = e?.localizedMessage.orEmpty()
         }
     }
 

--- a/ft-coroutines-retry/src/main/kotlin/tech/figure/coroutines/retry/flow/ObjectStoreRetryFlow.kt
+++ b/ft-coroutines-retry/src/main/kotlin/tech/figure/coroutines/retry/flow/ObjectStoreRetryFlow.kt
@@ -6,6 +6,9 @@ import kotlinx.coroutines.flow.asFlow
 import tech.figure.coroutines.retry.store.RetryRecord
 import tech.figure.coroutines.retry.store.RetryRecordStore
 
+const val DEFAULT_RETRY_GROUP_SIZE = 40
+const val DEFAULT_RETRY_COLLECTION_NAME = ""
+
 /**
  * Retry a flow of objects using the backing [store].
  *
@@ -16,7 +19,7 @@ import tech.figure.coroutines.retry.store.RetryRecordStore
 fun <T> recordStoreFlowRetry(
     handler: suspend (T) -> Unit,
     store: RetryRecordStore<T>,
-    groupSize: Int = 40,
+    groupSize: Int = DEFAULT_RETRY_GROUP_SIZE,
 ): FlowRetry<T> = RecordStoreFlowRetry(handler, store, groupSize)
 
 /**
@@ -29,7 +32,7 @@ fun <T> recordStoreFlowRetry(
 internal open class RecordStoreFlowRetry<T>(
     private val handler: suspend (T) -> Unit,
     private val store: RetryRecordStore<T>,
-    private val groupSize: Int = 40,
+    private val groupSize: Int = DEFAULT_RETRY_GROUP_SIZE,
 ) : FlowRetry<T> {
     override suspend fun produceNext(
         attemptRange: IntRange,

--- a/ft-coroutines-retry/src/main/kotlin/tech/figure/coroutines/retry/store/RetryRecord.kt
+++ b/ft-coroutines-retry/src/main/kotlin/tech/figure/coroutines/retry/store/RetryRecord.kt
@@ -6,8 +6,9 @@ open class RetryRecord<T>(
     var data: T,
     var attempt: Int = 0,
     var lastAttempted: OffsetDateTime = OffsetDateTime.now(),
-    var lastException: String = ""
+    var lastException: String = "",
+    var collection: String = "",
 ) {
     override fun toString(): String =
-        "RetryRecord(attempt:$attempt Exception:$lastException lastAttempted:$lastAttempted data:$data)"
+        "RetryRecord(attempt:$attempt exception:$lastException lastAttempted:$lastAttempted data:$data collection:$collection)"
 }


### PR DESCRIPTION
* Allows more fine grained control when working with a singular repo housing multiple records.