### PR TITLE
Wb/renovate wrapup

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 val gradleNexusVersion = "1.3.0"
 val kotlinVersion = "1.8.21"
 val ktLintVersion = "11.3.2"
-val dokkaVersion = "1.8.10"
+val dokkaVersion = "1.8.20"
 
 repositories {
 	gradlePluginPortal()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 val gradleNexusVersion = "1.3.0"
-val kotlinVersion = "1.8.21"
+val kotlinVersion = "1.9.0"
 val ktLintVersion = "11.3.2"
 val dokkaVersion = "1.8.20"
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 
 val gradleNexusVersion = "1.3.0"
 val kotlinVersion = "1.9.0"
-val ktLintVersion = "11.3.2"
 val dokkaVersion = "1.8.20"
+val ktLintVersion = "11.5.0"
 
 repositories {
 	gradlePluginPortal()

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -5,6 +5,6 @@ object Versions {
     }
 
     const val Kotest = "5.5.4"
-    const val KotlinLogging = "3.0.4"
+    const val KotlinLogging = "3.0.5"
     const val Kafka = "3.3.1"
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
     object Kotlinx {
-        const val Core = "1.7.2"
+        const val Core = "1.6.4"
         const val DateTime = "0.4.0"
     }
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
     object Kotlinx {
-        const val Core = "1.6.4"
+        const val Core = "1.7.2"
         const val DateTime = "0.4.0"
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kafka = "3.5.0"
-kotlinxCore = "1.7.2"
+kotlinxCore = "1.6.4"
 kotlinxCli = "0.3.5"
 kotlinxDateTime = "0.3.0"
 kotlinLogging = "3.0.5"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlinxCore = "1.7.2"
 kotlinxCli = "0.3.5"
 kotlinxDateTime = "0.3.0"
 kotlinLogging = "3.0.5"
-logback = "1.4.7"
+logback = "1.4.8"
 slf4jApi = "2.0.7"
 
 pluginNexusPublishPlugin = "1.3.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kafka = "3.4.0"
+kafka = "3.5.0"
 kotlinxCore = "1.7.2"
 kotlinxCli = "0.3.5"
 kotlinxDateTime = "0.3.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kafka = "3.4.0"
-kotlinxCore = "1.6.4"
+kotlinxCore = "1.7.2"
 kotlinxCli = "0.3.5"
 kotlinxDateTime = "0.3.0"
 kotlinLogging = "3.0.5"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,7 +32,7 @@ include("ft-coroutines-kafka")
 include("ft-coroutines-kafka-retry")
 
 plugins {
-    id("org.danilopianini.gradle-pre-commit-git-hooks") version "1.1.7"
+    id("org.danilopianini.gradle-pre-commit-git-hooks") version "1.1.9"
 }
 
 gitHooks {


### PR DESCRIPTION
Kotlinx updoot breaks things by making a interface we are using sealed. Keeping 1.6.4 for now