### PR TITLE
chore: update codeowners for new team structure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,1 @@
-# CODEOWNERS: https://help.github.com/articles/about-codeowners/
-#
-# NOTE: Order is important; the last matching pattern takes the most precedence.
-#
-# Secondary repo maintainers, substitutes of the primary maintainers when they become MIA
-
-# Primary code owners:
-*	@FigureTechnologies/team-rd
+* @FigureTechnologies/backend-markets-rd

--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -1,6 +1,6 @@
 schema-version: v2
 dd-service: ft-coroutines
-team: team-rd
+team: backend-markets-rd
 contacts:
 - type: slack
   contact: https://figure-group.slack.com/archives/C024YJBBBU0
@@ -11,4 +11,4 @@ repos:
 docs:
 - name: GitHub Team
   provider: github
-  url: https://github.com/orgs/FigureTechnologies/teams/team-rd/members
+  url: https://github.com/orgs/FigureTechnologies/teams/backend-markets-rd/members


### PR DESCRIPTION
**Problem:** 

We're updating team organization and codeowners to better match company & team structure

**Solution:**

Update this repo per assignments per [notion docs](https://www.notion.so/figuretech/1be68c6593194b989619f3f9af07b87d?v=ff5860acd9e8441bb374f42f68df7f08)